### PR TITLE
feat: add account registration and profile screen

### DIFF
--- a/lost_found_app/lib/controllers/auth_controller.dart
+++ b/lost_found_app/lib/controllers/auth_controller.dart
@@ -22,6 +22,33 @@ class AuthController {
     await _authService.signIn(trimmedEmail, trimmedPassword);
   }
 
+  Future<void> register({
+    required String email,
+    required String password,
+    required String confirmPassword,
+  }) async {
+    final trimmedEmail = email.trim();
+    final trimmedPassword = password.trim();
+
+    if (trimmedEmail.isEmpty || trimmedPassword.isEmpty) {
+      throw Exception('Email and password are required.');
+    }
+
+    if (!validateUniversityEmail(trimmedEmail)) {
+      throw Exception('Only @inf.elte.hu email addresses are allowed.');
+    }
+
+    if (trimmedPassword != confirmPassword.trim()) {
+      throw Exception('Passwords do not match.');
+    }
+
+    if (trimmedPassword.length < 6) {
+      throw Exception('Password must be at least 6 characters.');
+    }
+
+    await _authService.register(trimmedEmail, trimmedPassword);
+  }
+
   Future<void> logout() async {
     await _authService.signOut();
   }

--- a/lost_found_app/lib/services/auth_service.dart
+++ b/lost_found_app/lib/services/auth_service.dart
@@ -11,5 +11,9 @@ class AuthService {
     return _auth.signInWithEmailAndPassword(email: email, password: password);
   }
 
+  Future<UserCredential> register(String email, String password) {
+    return _auth.createUserWithEmailAndPassword(email: email, password: password);
+  }
+
   Future<void> signOut() => _auth.signOut();
 }

--- a/lost_found_app/lib/views/login/register_view.dart
+++ b/lost_found_app/lib/views/login/register_view.dart
@@ -3,49 +3,55 @@ import 'package:flutter/material.dart';
 
 import '../../controllers/auth_controller.dart';
 import '../../utils/app_theme.dart';
-import 'register_view.dart';
 
-class LoginView extends StatefulWidget {
-  const LoginView({super.key});
+class RegisterView extends StatefulWidget {
+  const RegisterView({super.key});
 
   @override
-  State<LoginView> createState() => _LoginViewState();
+  State<RegisterView> createState() => _RegisterViewState();
 }
 
-class _LoginViewState extends State<LoginView> {
+class _RegisterViewState extends State<RegisterView> {
   final AuthController _authController = AuthController();
 
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _confirmPasswordController =
+      TextEditingController();
 
   String _errorMessage = '';
   bool _isLoading = false;
+  bool _obscurePassword = true;
+  bool _obscureConfirm = true;
 
-  Future<void> _handleLogin() async {
+  Future<void> _handleRegister() async {
     setState(() {
       _errorMessage = '';
       _isLoading = true;
     });
 
     try {
-      await _authController.login(
+      await _authController.register(
         email: _emailController.text,
         password: _passwordController.text,
+        confirmPassword: _confirmPasswordController.text,
       );
-      // Navigation is handled by the StreamBuilder in app.dart.
+      // Pop back to root so the StreamBuilder in app.dart can show HomeView.
+      if (mounted) {
+        Navigator.of(context).popUntil((route) => route.isFirst);
+      }
     } on FirebaseAuthException catch (e) {
       setState(() {
         switch (e.code) {
-          case 'user-not-found':
-          case 'wrong-password':
-          case 'invalid-credential':
-            _errorMessage = 'Invalid email or password.';
-          case 'user-disabled':
-            _errorMessage = 'This account has been disabled.';
-          case 'too-many-requests':
-            _errorMessage = 'Too many attempts. Please try again later.';
+          case 'email-already-in-use':
+            _errorMessage =
+                'An account with this email already exists. Please log in.';
+          case 'weak-password':
+            _errorMessage = 'Password is too weak. Use at least 6 characters.';
+          case 'invalid-email':
+            _errorMessage = 'The email address is not valid.';
           default:
-            _errorMessage = 'Login failed. Please try again.';
+            _errorMessage = 'Registration failed. Please try again.';
         }
       });
     } on Exception catch (e) {
@@ -53,9 +59,7 @@ class _LoginViewState extends State<LoginView> {
         _errorMessage = e.toString().replaceFirst('Exception: ', '');
       });
     } finally {
-      if (mounted) {
-        setState(() => _isLoading = false);
-      }
+      if (mounted) setState(() => _isLoading = false);
     }
   }
 
@@ -63,6 +67,7 @@ class _LoginViewState extends State<LoginView> {
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();
+    _confirmPasswordController.dispose();
     super.dispose();
   }
 
@@ -71,7 +76,7 @@ class _LoginViewState extends State<LoginView> {
     final textTheme = Theme.of(context).textTheme;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Login')),
+      appBar: AppBar(title: const Text('Create Account')),
       body: Center(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(20),
@@ -85,13 +90,13 @@ class _LoginViewState extends State<LoginView> {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     Text(
-                      'Welcome back',
+                      'Create account',
                       style: textTheme.headlineMedium,
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 8),
                     Text(
-                      'Use your university account to enter the campus lost and found portal.',
+                      'Register with your @inf.elte.hu university email to access the campus lost and found portal.',
                       style: textTheme.bodyMedium,
                       textAlign: TextAlign.center,
                     ),
@@ -101,13 +106,43 @@ class _LoginViewState extends State<LoginView> {
                       keyboardType: TextInputType.emailAddress,
                       decoration: const InputDecoration(
                         labelText: 'University Email',
+                        hintText: 'yourname@inf.elte.hu',
                       ),
                     ),
                     const SizedBox(height: 16),
                     TextField(
                       controller: _passwordController,
-                      obscureText: true,
-                      decoration: const InputDecoration(labelText: 'Password'),
+                      obscureText: _obscurePassword,
+                      decoration: InputDecoration(
+                        labelText: 'Password',
+                        hintText: 'At least 6 characters',
+                        suffixIcon: IconButton(
+                          icon: Icon(
+                            _obscurePassword
+                                ? Icons.visibility_outlined
+                                : Icons.visibility_off_outlined,
+                          ),
+                          onPressed: () => setState(
+                              () => _obscurePassword = !_obscurePassword),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    TextField(
+                      controller: _confirmPasswordController,
+                      obscureText: _obscureConfirm,
+                      decoration: InputDecoration(
+                        labelText: 'Confirm Password',
+                        suffixIcon: IconButton(
+                          icon: Icon(
+                            _obscureConfirm
+                                ? Icons.visibility_outlined
+                                : Icons.visibility_off_outlined,
+                          ),
+                          onPressed: () => setState(
+                              () => _obscureConfirm = !_obscureConfirm),
+                        ),
+                      ),
                     ),
                     const SizedBox(height: 16),
                     if (_errorMessage.isNotEmpty)
@@ -120,23 +155,20 @@ class _LoginViewState extends State<LoginView> {
                       ),
                     if (_errorMessage.isNotEmpty) const SizedBox(height: 16),
                     ElevatedButton(
-                      onPressed: _isLoading ? null : _handleLogin,
+                      onPressed: _isLoading ? null : _handleRegister,
                       child: _isLoading
                           ? const SizedBox(
                               height: 20,
                               width: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
+                              child:
+                                  CircularProgressIndicator(strokeWidth: 2),
                             )
-                          : const Text('Login'),
+                          : const Text('Create Account'),
                     ),
                     const SizedBox(height: 12),
                     TextButton(
-                      onPressed: () => Navigator.of(context).push(
-                        MaterialPageRoute<void>(
-                          builder: (_) => const RegisterView(),
-                        ),
-                      ),
-                      child: const Text("Don't have an account? Register"),
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: const Text('Already have an account? Log in'),
                     ),
                   ],
                 ),

--- a/lost_found_app/lib/views/profile_view.dart/profile_view.dart
+++ b/lost_found_app/lib/views/profile_view.dart/profile_view.dart
@@ -1,0 +1,324 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+import '../../controllers/auth_controller.dart';
+import '../../utils/app_theme.dart';
+
+class ProfileView extends StatelessWidget {
+  const ProfileView({super.key});
+
+  String _initials(String? email) {
+    if (email == null || email.isEmpty) return '?';
+    final name = email.split('@').first;
+    final parts = name.split('.');
+    if (parts.length >= 2) {
+      return '${parts[0][0]}${parts[1][0]}'.toUpperCase();
+    }
+    return name.substring(0, name.length >= 2 ? 2 : 1).toUpperCase();
+  }
+
+  String _formatDate(DateTime? dt) {
+    if (dt == null) return 'Unknown';
+    const months = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ];
+    return '${months[dt.month - 1]} ${dt.day}, ${dt.year}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+    final email = user?.email ?? '';
+    final initials = _initials(email);
+    final memberSince = _formatDate(user?.metadata.creationTime);
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      body: Column(
+        children: [
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.fromLTRB(20, 60, 20, 32),
+            decoration: const BoxDecoration(
+              gradient: AppTheme.primaryGradient,
+              borderRadius: BorderRadius.only(
+                bottomLeft: Radius.circular(36),
+                bottomRight: Radius.circular(36),
+              ),
+            ),
+            child: Column(
+              children: [
+                Row(
+                  children: [
+                    IconButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      icon: const Icon(
+                        Icons.arrow_back_ios_new_rounded,
+                        color: Colors.white,
+                        size: 22,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      'My Profile',
+                      style: textTheme.titleLarge?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                CircleAvatar(
+                  radius: 48,
+                  backgroundColor: Colors.white24,
+                  child: Text(
+                    initials,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 32,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  email,
+                  style: textTheme.titleMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 6,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Colors.white24,
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Text(
+                    'ELTE University Student',
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(20, 28, 20, 20),
+              children: [
+                _SectionLabel(label: 'Account Details'),
+                const SizedBox(height: 12),
+                _InfoCard(
+                  icon: Icons.email_outlined,
+                  label: 'Email Address',
+                  value: email,
+                ),
+                const SizedBox(height: 12),
+                _InfoCard(
+                  icon: Icons.school_outlined,
+                  label: 'University',
+                  value: 'Eötvös Loránd University',
+                ),
+                const SizedBox(height: 12),
+                _InfoCard(
+                  icon: Icons.apartment_outlined,
+                  label: 'Faculty',
+                  value: 'Faculty of Informatics (inf.elte.hu)',
+                ),
+                const SizedBox(height: 12),
+                _InfoCard(
+                  icon: Icons.calendar_today_outlined,
+                  label: 'Member Since',
+                  value: memberSince,
+                ),
+                const SizedBox(height: 32),
+                _SectionLabel(label: 'Actions'),
+                const SizedBox(height: 12),
+                _LogoutButton(),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label,
+      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+        color: AppTheme.textSecondary,
+        fontWeight: FontWeight.w700,
+        fontSize: 13,
+        letterSpacing: 0.8,
+      ),
+    );
+  }
+}
+
+class _InfoCard extends StatelessWidget {
+  const _InfoCard({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: AppTheme.border),
+        boxShadow: [
+          BoxShadow(
+            color: AppTheme.secondary.withValues(alpha: 0.05),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 44,
+            height: 44,
+            decoration: BoxDecoration(
+              color: AppTheme.primary.withValues(alpha: 0.10),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(icon, color: AppTheme.primary, size: 22),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: textTheme.bodySmall?.copyWith(
+                    color: AppTheme.textSecondary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  value,
+                  style: textTheme.titleMedium?.copyWith(
+                    color: AppTheme.secondary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LogoutButton extends StatefulWidget {
+  @override
+  State<_LogoutButton> createState() => _LogoutButtonState();
+}
+
+class _LogoutButtonState extends State<_LogoutButton> {
+  bool _isLoading = false;
+
+  Future<void> _handleLogout() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Log Out'),
+        content: const Text('Are you sure you want to log out?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+            child: const Text('Log Out'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    setState(() => _isLoading = true);
+    try {
+      if (mounted) {
+        Navigator.of(context).popUntil((route) => route.isFirst);
+      }
+      await AuthController().logout();
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: _isLoading ? null : _handleLogout,
+        style: OutlinedButton.styleFrom(
+          foregroundColor: AppTheme.error,
+          side: BorderSide(color: AppTheme.error.withValues(alpha: 0.5)),
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+        icon: _isLoading
+            ? const SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : const Icon(Icons.logout_rounded),
+        label: const Text(
+          'Log Out',
+          style: TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
+        ),
+      ),
+    );
+  }
+}

--- a/lost_found_app/lib/widgets/home_header.dart
+++ b/lost_found_app/lib/widgets/home_header.dart
@@ -1,12 +1,26 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:lost_found_app/utils/app_theme.dart';
+import 'package:lost_found_app/views/profile_view.dart/profile_view.dart';
 
 class HomeHeader extends StatelessWidget {
   const HomeHeader({super.key});
 
+  String _initials(String? email) {
+    if (email == null || email.isEmpty) return '?';
+    final name = email.split('@').first;
+    final parts = name.split('.');
+    if (parts.length >= 2) {
+      return '${parts[0][0]}${parts[1][0]}'.toUpperCase();
+    }
+    return name.substring(0, name.length >= 2 ? 2 : 1).toUpperCase();
+  }
+
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final email = FirebaseAuth.instance.currentUser?.email;
+    final initials = _initials(email);
 
     return Container(
       height: 125,
@@ -24,14 +38,21 @@ class HomeHeader extends StatelessWidget {
         children: [
           Row(
             children: [
-              const CircleAvatar(
-                radius: 26,
-                backgroundColor: Colors.white24,
-                child: Text(
-                  "JS",
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontWeight: FontWeight.bold,
+              GestureDetector(
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const ProfileView(),
+                  ),
+                ),
+                child: CircleAvatar(
+                  radius: 26,
+                  backgroundColor: Colors.white24,
+                  child: Text(
+                    initials,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
Registration:
- Add register() to AuthService using createUserWithEmailAndPassword
- Add register() to AuthController with domain, password match, and min-length validations
- Add RegisterView with email, password, confirm password fields, show/hide toggles, loading state, and Firebase error mapping
- Fix post-registration navigation: popUntil(root) so StreamBuilder transitions to HomeView cleanly
- Add "Don't have an account? Register" link on LoginView

Profile screen:
- Add ProfileView showing avatar initials, email, university, faculty, and member-since date from Firebase Auth metadata
- Add logout button with confirmation dialog
- Fix logout navigation: pop to root before signOut() so StreamBuilder transitions HomeView → LoginView smoothly
- Update HomeHeader avatar to show real initials from current user email and tap to open ProfileView