### PR TITLE
feat: Implement notification history view with item detail navigation

### DIFF
--- a/lost_found_app/android/app/build.gradle.kts
+++ b/lost_found_app/android/app/build.gradle.kts
@@ -14,6 +14,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -42,4 +43,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }

--- a/lost_found_app/lib/controllers/notification_controller.dart
+++ b/lost_found_app/lib/controllers/notification_controller.dart
@@ -1,33 +1,27 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 import '../models/notification_model.dart';
 
 class NotificationController {
-  final List<NotificationModel> _notifications = [];
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
 
-  void addNotification(NotificationModel notification) {
-    _notifications.add(notification);
-  }
-
-  List<NotificationModel> getUserNotifications(String userId) {
-    return _notifications
-        .where((notification) => notification.userId == userId)
-        .toList();
-  }
-
-  void markAsRead(String notificationId) {
-    for (int i = 0; i < _notifications.length; i++) {
-      if (_notifications[i].id == notificationId) {
-        final notification = _notifications[i];
-
-        _notifications[i] = NotificationModel(
-          id: notification.id,
-          title: notification.title,
-          message: notification.message,
-          userId: notification.userId,
-          createdAt: notification.createdAt,
-          isRead: true,
+  Stream<List<NotificationModel>> getUserNotifications(String userId) {
+    return _db
+        .collection('notifications')
+        .where('toUserId', isEqualTo: userId)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map(
+          (snapshot) => snapshot.docs
+              .map((doc) => NotificationModel.fromFirestore(doc))
+              .toList(),
         );
-        break;
-      }
-    }
+  }
+
+  Future<void> markAsRead(String notificationId) async {
+    await _db
+        .collection('notifications')
+        .doc(notificationId)
+        .update({'read': true});
   }
 }

--- a/lost_found_app/lib/main.dart
+++ b/lost_found_app/lib/main.dart
@@ -1,11 +1,14 @@
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 
 import 'app.dart';
 import 'firebase_options.dart';
+import 'services/notification_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
   runApp(const MyApp());
 }

--- a/lost_found_app/lib/models/notification_model.dart
+++ b/lost_found_app/lib/models/notification_model.dart
@@ -1,41 +1,40 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class NotificationModel {
   final String id;
+  final String toUserId;
   final String title;
-  final String message;
-  final String userId;
+  final String body;
+  final String newItemId;
+  final String newItemType;
+  final String matchedItemId;
+  final bool read;
   final DateTime createdAt;
-  final bool isRead;
 
   const NotificationModel({
     required this.id,
+    required this.toUserId,
     required this.title,
-    required this.message,
-    required this.userId,
+    required this.body,
+    required this.newItemId,
+    required this.newItemType,
+    required this.matchedItemId,
+    required this.read,
     required this.createdAt,
-    required this.isRead,
   });
 
-  factory NotificationModel.fromMap(Map<String, dynamic> map) {
+  factory NotificationModel.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
     return NotificationModel(
-      id: map['id'] as String? ?? '',
-      title: map['title'] as String? ?? '',
-      message: map['message'] as String? ?? '',
-      userId: map['userId'] as String? ?? '',
-      createdAt:
-          DateTime.tryParse(map['createdAt'] as String? ?? '') ??
-          DateTime.now(),
-      isRead: map['isRead'] as bool? ?? false,
+      id: doc.id,
+      toUserId: data['toUserId'] as String? ?? '',
+      title: data['title'] as String? ?? '',
+      body: data['body'] as String? ?? '',
+      newItemId: data['newItemId'] as String? ?? '',
+      newItemType: data['newItemType'] as String? ?? '',
+      matchedItemId: data['matchedItemId'] as String? ?? '',
+      read: data['read'] as bool? ?? false,
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
     );
-  }
-
-  Map<String, dynamic> toMap() {
-    return {
-      'id': id,
-      'title': title,
-      'message': message,
-      'userId': userId,
-      'createdAt': createdAt.toIso8601String(),
-      'isRead': isRead,
-    };
   }
 }

--- a/lost_found_app/lib/services/notification_service.dart
+++ b/lost_found_app/lib/services/notification_service.dart
@@ -6,6 +6,13 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 final FlutterLocalNotificationsPlugin _localNotifications =
     FlutterLocalNotificationsPlugin();
 
+const _androidChannel = AndroidNotificationChannel(
+  'matches', // must match the channelId sent from Cloud Function
+  'Match Notifications',
+  description: 'Notifications for lost & found item matches',
+  importance: Importance.high,
+);
+
 @pragma('vm:entry-point')
 Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {}
 
@@ -32,27 +39,34 @@ class NotificationService {
     if (!granted) return;
 
     // 2. Set up local notifications for foreground display
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
     const iosSettings = DarwinInitializationSettings(
       requestAlertPermission: false,
       requestBadgePermission: false,
       requestSoundPermission: false,
     );
     await _localNotifications.initialize(
-      const InitializationSettings(iOS: iosSettings),
+      const InitializationSettings(android: androidSettings, iOS: iosSettings),
     );
 
-    // 3. Tell FCM to show notifications in foreground on iOS
+    // 3. Create Android notification channel
+    await _localNotifications
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(_androidChannel);
+
+    // 4. Tell FCM to show notifications in foreground on iOS
     await _messaging.setForegroundNotificationPresentationOptions(
       alert: true,
       badge: true,
       sound: true,
     );
 
-    // 4. Save token to Firestore
+    // 5. Save token to Firestore
     await _saveToken();
     _messaging.onTokenRefresh.listen(_saveTokenToFirestore);
 
-    // 5. Handle foreground messages — show as native notification
+    // 6. Handle foreground messages — show as native notification
     FirebaseMessaging.onMessage.listen((message) {
       final notification = message.notification;
       if (notification == null) return;
@@ -61,8 +75,16 @@ class NotificationService {
         notification.hashCode,
         notification.title,
         notification.body,
-        const NotificationDetails(
-          iOS: DarwinNotificationDetails(
+        NotificationDetails(
+          android: AndroidNotificationDetails(
+            _androidChannel.id,
+            _androidChannel.name,
+            channelDescription: _androidChannel.description,
+            importance: Importance.high,
+            priority: Priority.high,
+            icon: '@mipmap/ic_launcher',
+          ),
+          iOS: const DarwinNotificationDetails(
             presentAlert: true,
             presentBadge: true,
             presentSound: true,

--- a/lost_found_app/lib/views/notifications/notifications_view.dart
+++ b/lost_found_app/lib/views/notifications/notifications_view.dart
@@ -1,0 +1,302 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:lost_found_app/models/item_report_model.dart';
+import 'package:lost_found_app/models/notification_model.dart';
+import 'package:lost_found_app/utils/app_theme.dart';
+import 'package:lost_found_app/widgets/item_widgets.dart';
+
+const _categoryColors = <String, (Color, Color)>{
+  'Electronics': (Color(0xFF99F6E4), Color(0xFF0F766E)),
+  'Accessories': (Color(0xFFEDE9FE), Color(0xFF7C3AED)),
+  'Bottles': (Color(0xFFDCFCE7), Color(0xFF15803D)),
+  'Documents': (Color(0xFFFEF3C7), Color(0xFFF59E0B)),
+  'IDs': (Color(0xFFEDE9FE), Color(0xFF7C3AED)),
+  'Keys': (Color(0xFFFEF3C7), Color(0xFFF59E0B)),
+  'Books': (Color(0xFFFCE7F3), Color(0xFFDB2777)),
+  'Other': (Color(0xFFE0F2FE), Color(0xFF0284C7)),
+};
+
+const _categoryIcons = <String, IconData>{
+  'Electronics': Icons.devices_rounded,
+  'Accessories': Icons.watch_rounded,
+  'Bottles': Icons.local_drink_rounded,
+  'Documents': Icons.description_rounded,
+  'IDs': Icons.badge_rounded,
+  'Keys': Icons.key_rounded,
+  'Books': Icons.book_rounded,
+  'Other': Icons.category_rounded,
+};
+
+String _formatDate(DateTime dt) {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[dt.month - 1]} ${dt.day}, ${dt.year}';
+}
+
+ItemData _toItemData(ItemReportModel model) {
+  final colors =
+      _categoryColors[model.category] ??
+      (const Color(0xFFE2E8F0), const Color(0xFF64748B));
+  return ItemData(
+    isLost: model.type == 'lost',
+    title: model.title,
+    description: model.description,
+    location: model.location,
+    date: _formatDate(model.date),
+    category: model.category,
+    contactEmail: model.userId,
+    icon: _categoryIcons[model.category] ?? Icons.help_outline_rounded,
+    backgroundColor: colors.$1,
+    accentColor: colors.$2,
+    imageUrl: model.imageUrl,
+  );
+}
+
+class NotificationsView extends StatelessWidget {
+  const NotificationsView({super.key});
+
+  Future<void> _markAsRead(String docId) async {
+    await FirebaseFirestore.instance
+        .collection('notifications')
+        .doc(docId)
+        .update({'read': true});
+  }
+
+  Future<void> _openMatchedItem(
+    BuildContext context,
+    NotificationModel n,
+  ) async {
+    if (!n.read) await _markAsRead(n.id);
+
+    // Determine which collection the new item belongs to
+    final collection = n.newItemType == 'found' ? 'found_items' : 'lost_items';
+
+    final doc = await FirebaseFirestore.instance
+        .collection(collection)
+        .doc(n.newItemId)
+        .get();
+
+    if (!doc.exists || !context.mounted) return;
+
+    final item = ItemReportModel.fromFirestore(doc);
+    final itemData = _toItemData(item);
+
+    if (!context.mounted) return;
+
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => DraggableScrollableSheet(
+        initialChildSize: 0.75,
+        minChildSize: 0.5,
+        maxChildSize: 0.95,
+        builder: (context, scrollController) =>
+            ItemDetailsView(item: itemData, scrollController: scrollController),
+      ),
+    );
+  }
+
+  String _timeAgo(DateTime date) {
+    final diff = DateTime.now().difference(date);
+    if (diff.inMinutes < 1) return 'Just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF5F7F5),
+      appBar: AppBar(
+        toolbarHeight: 100,
+        title: const Text(
+          'Notifications',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+            fontSize: 20,
+          ),
+        ),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        flexibleSpace: Container(
+          decoration: const BoxDecoration(gradient: AppTheme.primaryGradient),
+        ),
+        foregroundColor: Colors.white,
+      ),
+      body: uid.isEmpty
+          ? const Center(child: Text('Not logged in'))
+          : StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('notifications')
+            .where('toUserId', isEqualTo: uid)
+            .orderBy('createdAt', descending: true)
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+
+          if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+            return const Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.notifications_off_outlined,
+                    size: 64,
+                    color: Colors.grey,
+                  ),
+                  SizedBox(height: 16),
+                  Text(
+                    'No notifications yet',
+                    style: TextStyle(fontSize: 16, color: Colors.grey),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final notifications = snapshot.data!.docs
+              .map((doc) => NotificationModel.fromFirestore(doc))
+              .toList();
+
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: notifications.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 10),
+            itemBuilder: (context, index) {
+              final n = notifications[index];
+              return GestureDetector(
+                onTap: () => _openMatchedItem(context, n),
+                child: Container(
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: n.read ? Colors.white : const Color(0xFFEAF3EB),
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(
+                      color: n.read
+                          ? Colors.transparent
+                          : const Color(0xFF5D8A66).withValues(alpha: 0.4),
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.05),
+                        blurRadius: 8,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Container(
+                        width: 44,
+                        height: 44,
+                        decoration: BoxDecoration(
+                          color: const Color(
+                            0xFF5D8A66,
+                          ).withValues(alpha: 0.15),
+                          shape: BoxShape.circle,
+                        ),
+                        child: Icon(
+                          n.newItemType == 'found'
+                              ? Icons.search
+                              : Icons.campaign_outlined,
+                          color: const Color(0xFF5D8A66),
+                          size: 22,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: Text(
+                                    n.title,
+                                    style: TextStyle(
+                                      fontWeight: n.read
+                                          ? FontWeight.w500
+                                          : FontWeight.bold,
+                                      fontSize: 15,
+                                    ),
+                                  ),
+                                ),
+                                if (!n.read)
+                                  Container(
+                                    width: 8,
+                                    height: 8,
+                                    decoration: const BoxDecoration(
+                                      color: Color(0xFF5D8A66),
+                                      shape: BoxShape.circle,
+                                    ),
+                                  ),
+                              ],
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              n.body,
+                              style: const TextStyle(
+                                fontSize: 13,
+                                color: Colors.black54,
+                              ),
+                            ),
+                            const SizedBox(height: 6),
+                            Row(
+                              children: [
+                                Text(
+                                  _timeAgo(n.createdAt),
+                                  style: const TextStyle(
+                                    fontSize: 12,
+                                    color: Colors.grey,
+                                  ),
+                                ),
+                                const Spacer(),
+                                const Text(
+                                  'Tap to view item →',
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    color: Color(0xFF5D8A66),
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lost_found_app/lib/views/report/report_found_item_view.dart
+++ b/lost_found_app/lib/views/report/report_found_item_view.dart
@@ -90,6 +90,12 @@ class _ReportFoundItemViewState extends State<ReportFoundItemView> {
     });
   }
 
+  void _skipPhoto() {
+    setState(() {
+      _step += 1;
+    });
+  }
+
   Future<void> _goNext() async {
     if (!_canContinue || _isSubmitting) return;
 
@@ -236,7 +242,7 @@ class _ReportFoundItemViewState extends State<ReportFoundItemView> {
                           imagePath: _selectedImagePath,
                           permissionMessage: _photoPermissionMessage,
                           onPickPhoto: _pickGalleryImage,
-                          onSkip: _goNext,
+                          onSkip: _skipPhoto,
                         ),
                       ],
                       1 => [

--- a/lost_found_app/lib/widgets/home_header.dart
+++ b/lost_found_app/lib/widgets/home_header.dart
@@ -1,6 +1,8 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:lost_found_app/utils/app_theme.dart';
+import 'package:lost_found_app/views/notifications/notifications_view.dart';
 import 'package:lost_found_app/views/profile_view.dart/profile_view.dart';
 
 class HomeHeader extends StatelessWidget {
@@ -75,26 +77,54 @@ class HomeHeader extends StatelessWidget {
               ),
             ],
           ),
-          Stack(
-            children: [
-              const Icon(
-                Icons.notifications_none,
-                size: 28,
-                color: Colors.white,
+          GestureDetector(
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => const NotificationsView(),
               ),
-              // Positioned(
-              //   right: 0,
-              //   top: 0,
-              //   child: Container(
-              //     width: 10,
-              //     height: 10,
-              //     decoration: const BoxDecoration(
-              //       color: Colors.red,
-              //       shape: BoxShape.circle,
-              //     ),
-              //   ),
-              // ),
-            ],
+            ),
+            child: StreamBuilder<QuerySnapshot>(
+              stream: FirebaseFirestore.instance
+                  .collection('notifications')
+                  .where('toUserId', isEqualTo: FirebaseAuth.instance.currentUser?.uid ?? '')
+                  .where('read', isEqualTo: false)
+                  .snapshots(),
+              builder: (context, snapshot) {
+                final unreadCount = snapshot.data?.docs.length ?? 0;
+                return Stack(
+                  children: [
+                    const Icon(
+                      Icons.notifications_none,
+                      size: 28,
+                      color: Colors.white,
+                    ),
+                    if (unreadCount > 0)
+                      Positioned(
+                        right: 0,
+                        top: 0,
+                        child: Container(
+                          width: 16,
+                          height: 16,
+                          decoration: const BoxDecoration(
+                            color: Colors.red,
+                            shape: BoxShape.circle,
+                          ),
+                          child: Center(
+                            child: Text(
+                              unreadCount > 9 ? '9+' : '$unreadCount',
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 10,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                );
+              },
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
- Created NotificationsView with Firestore stream filtered by toUserId
- Added unread badge on bell icon in HomeHeader with real-time count
- Tapping a notification marks it as read and opens matched item in bottom sheet
- Rewrote NotificationModel to match Firestore document structure
- Rewrote NotificationController to use Firestore streams
- Fixed Android foreground notifications with notification channel setup
- Registered firebaseMessagingBackgroundHandler in main.dart
- Fixed Skip for now button on found item photo step