### PR TITLE
feat: Filter items by open status and restrict date picker to past dates

### DIFF
--- a/lost_found_app/lib/services/database_service.dart
+++ b/lost_found_app/lib/services/database_service.dart
@@ -12,17 +12,25 @@ class DatabaseService {
   Stream<List<ItemReportModel>> getLostItems() {
     return _db
         .collection('lost_items')
-        .orderBy('date', descending: true)
+        .where('status', isEqualTo: 'open')
         .snapshots()
-        .map((snap) => snap.docs.map(ItemReportModel.fromFirestore).toList());
+        .map((snap) {
+          final items = snap.docs.map(ItemReportModel.fromFirestore).toList();
+          items.sort((a, b) => b.date.compareTo(a.date));
+          return items;
+        });
   }
 
   Stream<List<ItemReportModel>> getFoundItems() {
     return _db
         .collection('found_items')
-        .orderBy('date', descending: true)
+        .where('status', isEqualTo: 'open')
         .snapshots()
-        .map((snap) => snap.docs.map(ItemReportModel.fromFirestore).toList());
+        .map((snap) {
+          final items = snap.docs.map(ItemReportModel.fromFirestore).toList();
+          items.sort((a, b) => b.date.compareTo(a.date));
+          return items;
+        });
   }
 
   Stream<List<ItemReportModel>> getUserItems(String userId) {

--- a/lost_found_app/lib/views/notifications/notifications_view.dart
+++ b/lost_found_app/lib/views/notifications/notifications_view.dart
@@ -126,7 +126,7 @@ class NotificationsView extends StatelessWidget {
     return Scaffold(
       backgroundColor: const Color(0xFFF5F7F5),
       appBar: AppBar(
-        toolbarHeight: 100,
+        toolbarHeight: 75,
         title: const Text(
           'Notifications',
           style: TextStyle(
@@ -145,159 +145,163 @@ class NotificationsView extends StatelessWidget {
       body: uid.isEmpty
           ? const Center(child: Text('Not logged in'))
           : StreamBuilder<QuerySnapshot>(
-        stream: FirebaseFirestore.instance
-            .collection('notifications')
-            .where('toUserId', isEqualTo: uid)
-            .orderBy('createdAt', descending: true)
-            .snapshots(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
+              stream: FirebaseFirestore.instance
+                  .collection('notifications')
+                  .where('toUserId', isEqualTo: uid)
+                  .orderBy('createdAt', descending: true)
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
 
-          if (snapshot.hasError) {
-            return Center(child: Text('Error: ${snapshot.error}'));
-          }
+                if (snapshot.hasError) {
+                  return Center(child: Text('Error: ${snapshot.error}'));
+                }
 
-          if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-            return const Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.notifications_off_outlined,
-                    size: 64,
-                    color: Colors.grey,
-                  ),
-                  SizedBox(height: 16),
-                  Text(
-                    'No notifications yet',
-                    style: TextStyle(fontSize: 16, color: Colors.grey),
-                  ),
-                ],
-              ),
-            );
-          }
-
-          final notifications = snapshot.data!.docs
-              .map((doc) => NotificationModel.fromFirestore(doc))
-              .toList();
-
-          return ListView.separated(
-            padding: const EdgeInsets.all(16),
-            itemCount: notifications.length,
-            separatorBuilder: (_, __) => const SizedBox(height: 10),
-            itemBuilder: (context, index) {
-              final n = notifications[index];
-              return GestureDetector(
-                onTap: () => _openMatchedItem(context, n),
-                child: Container(
-                  padding: const EdgeInsets.all(16),
-                  decoration: BoxDecoration(
-                    color: n.read ? Colors.white : const Color(0xFFEAF3EB),
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(
-                      color: n.read
-                          ? Colors.transparent
-                          : const Color(0xFF5D8A66).withValues(alpha: 0.4),
+                if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                  return const Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          Icons.notifications_off_outlined,
+                          size: 64,
+                          color: Colors.grey,
+                        ),
+                        SizedBox(height: 16),
+                        Text(
+                          'No notifications yet',
+                          style: TextStyle(fontSize: 16, color: Colors.grey),
+                        ),
+                      ],
                     ),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.05),
-                        blurRadius: 8,
-                        offset: const Offset(0, 2),
-                      ),
-                    ],
-                  ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Container(
-                        width: 44,
-                        height: 44,
+                  );
+                }
+
+                final notifications = snapshot.data!.docs
+                    .map((doc) => NotificationModel.fromFirestore(doc))
+                    .toList();
+
+                return ListView.separated(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: notifications.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 10),
+                  itemBuilder: (context, index) {
+                    final n = notifications[index];
+                    return GestureDetector(
+                      onTap: () => _openMatchedItem(context, n),
+                      child: Container(
+                        padding: const EdgeInsets.all(16),
                         decoration: BoxDecoration(
-                          color: const Color(
-                            0xFF5D8A66,
-                          ).withValues(alpha: 0.15),
-                          shape: BoxShape.circle,
+                          color: n.read
+                              ? Colors.white
+                              : const Color(0xFFEAF3EB),
+                          borderRadius: BorderRadius.circular(16),
+                          border: Border.all(
+                            color: n.read
+                                ? Colors.transparent
+                                : const Color(
+                                    0xFF5D8A66,
+                                  ).withValues(alpha: 0.4),
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withValues(alpha: 0.05),
+                              blurRadius: 8,
+                              offset: const Offset(0, 2),
+                            ),
+                          ],
                         ),
-                        child: Icon(
-                          n.newItemType == 'found'
-                              ? Icons.search
-                              : Icons.campaign_outlined,
-                          color: const Color(0xFF5D8A66),
-                          size: 22,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Column(
+                        child: Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    n.title,
-                                    style: TextStyle(
-                                      fontWeight: n.read
-                                          ? FontWeight.w500
-                                          : FontWeight.bold,
-                                      fontSize: 15,
-                                    ),
-                                  ),
-                                ),
-                                if (!n.read)
-                                  Container(
-                                    width: 8,
-                                    height: 8,
-                                    decoration: const BoxDecoration(
-                                      color: Color(0xFF5D8A66),
-                                      shape: BoxShape.circle,
-                                    ),
-                                  ),
-                              ],
-                            ),
-                            const SizedBox(height: 4),
-                            Text(
-                              n.body,
-                              style: const TextStyle(
-                                fontSize: 13,
-                                color: Colors.black54,
+                            Container(
+                              width: 44,
+                              height: 44,
+                              decoration: BoxDecoration(
+                                color: const Color(
+                                  0xFF5D8A66,
+                                ).withValues(alpha: 0.15),
+                                shape: BoxShape.circle,
+                              ),
+                              child: Icon(
+                                n.newItemType == 'found'
+                                    ? Icons.search
+                                    : Icons.campaign_outlined,
+                                color: const Color(0xFF5D8A66),
+                                size: 22,
                               ),
                             ),
-                            const SizedBox(height: 6),
-                            Row(
-                              children: [
-                                Text(
-                                  _timeAgo(n.createdAt),
-                                  style: const TextStyle(
-                                    fontSize: 12,
-                                    color: Colors.grey,
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                        child: Text(
+                                          n.title,
+                                          style: TextStyle(
+                                            fontWeight: n.read
+                                                ? FontWeight.w500
+                                                : FontWeight.bold,
+                                            fontSize: 15,
+                                          ),
+                                        ),
+                                      ),
+                                      if (!n.read)
+                                        Container(
+                                          width: 8,
+                                          height: 8,
+                                          decoration: const BoxDecoration(
+                                            color: Color(0xFF5D8A66),
+                                            shape: BoxShape.circle,
+                                          ),
+                                        ),
+                                    ],
                                   ),
-                                ),
-                                const Spacer(),
-                                const Text(
-                                  'Tap to view item →',
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    color: Color(0xFF5D8A66),
-                                    fontWeight: FontWeight.w600,
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    n.body,
+                                    style: const TextStyle(
+                                      fontSize: 13,
+                                      color: Colors.black54,
+                                    ),
                                   ),
-                                ),
-                              ],
+                                  const SizedBox(height: 6),
+                                  Row(
+                                    children: [
+                                      Text(
+                                        _timeAgo(n.createdAt),
+                                        style: const TextStyle(
+                                          fontSize: 12,
+                                          color: Colors.grey,
+                                        ),
+                                      ),
+                                      const Spacer(),
+                                      const Text(
+                                        'Tap to view item →',
+                                        style: TextStyle(
+                                          fontSize: 12,
+                                          color: Color(0xFF5D8A66),
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
                             ),
                           ],
                         ),
                       ),
-                    ],
-                  ),
-                ),
-              );
-            },
-          );
-        },
-      ),
+                    );
+                  },
+                );
+              },
+            ),
     );
   }
 }

--- a/lost_found_app/lib/views/report/report_found_item_view.dart
+++ b/lost_found_app/lib/views/report/report_found_item_view.dart
@@ -181,8 +181,8 @@ class _ReportFoundItemViewState extends State<ReportFoundItemView> {
     final picked = await showDatePicker(
       context: context,
       initialDate: _dateFound ?? DateTime.now(),
-      firstDate: DateTime(2024),
-      lastDate: DateTime(2030),
+      firstDate: DateTime(2026),
+      lastDate: DateTime.now(),
     );
 
     if (picked != null) {
@@ -461,7 +461,6 @@ class _FoundProgressHeader extends StatelessWidget {
     );
   }
 }
-
 
 class _FoundStepHeader extends StatelessWidget {
   const _FoundStepHeader({

--- a/lost_found_app/lib/views/report/report_lost_item_view.dart
+++ b/lost_found_app/lib/views/report/report_lost_item_view.dart
@@ -154,8 +154,8 @@ class _ReportLostItemViewState extends State<ReportLostItemView> {
     final picked = await showDatePicker(
       context: context,
       initialDate: _dateLost ?? DateTime.now(),
-      firstDate: DateTime(2024),
-      lastDate: DateTime(2030),
+      firstDate: DateTime(2026),
+      lastDate: DateTime.now(),
     );
 
     if (picked != null) {

--- a/lost_found_app/lib/widgets/item_widgets.dart
+++ b/lost_found_app/lib/widgets/item_widgets.dart
@@ -387,15 +387,12 @@ class _ItemDetailsViewState extends State<ItemDetailsView> {
   }
 
   Future<void> _fetchEmail() async {
-    print('=== _fetchEmail called, userId: ${widget.item.userId}');
     if (widget.item.userId.isEmpty) return;
     final doc = await FirebaseFirestore.instance
         .collection('users')
         .doc(widget.item.userId)
         .get();
-    print('=== doc exists: ${doc.exists}, data: ${doc.data()}');
     final email = doc.data()?['email'] as String? ?? '';
-    print('=== resolved email: $email');
     if (email.isNotEmpty && mounted) {
       setState(() => _resolvedEmail = email);
     }


### PR DESCRIPTION
- Filter lost/found lists to only show open items (sort in-memory to avoid Firestore index)
- Restrict date picker to past/present dates only in report views
- Remove debug print statements from ItemDetailsView