### PR TITLE
feat: add email verification on registration

### DIFF
--- a/lost_found_app/lib/app.dart
+++ b/lost_found_app/lib/app.dart
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
               body: Center(child: CircularProgressIndicator()),
             );
           }
-          if (snapshot.hasData) {
+          if (snapshot.hasData && snapshot.data!.emailVerified) {
             // Initialize FCM token saving and foreground message listener
             NotificationService().initialize();
             return const HomeView();

--- a/lost_found_app/lib/controllers/auth_controller.dart
+++ b/lost_found_app/lib/controllers/auth_controller.dart
@@ -49,6 +49,10 @@ class AuthController {
     await _authService.register(trimmedEmail, trimmedPassword);
   }
 
+  Future<void> sendVerificationEmail() async {
+    await _authService.sendVerificationEmail();
+  }
+
   Future<void> logout() async {
     await _authService.signOut();
   }

--- a/lost_found_app/lib/services/auth_service.dart
+++ b/lost_found_app/lib/services/auth_service.dart
@@ -9,20 +9,35 @@ class AuthService {
 
   User? get currentUser => _auth.currentUser;
 
-  Future<UserCredential> signIn(String email, String password) {
-    return _auth.signInWithEmailAndPassword(email: email, password: password);
-  }
-
-  Future<UserCredential> register(String email, String password) async {
-    final credential = await _auth.createUserWithEmailAndPassword(
+  Future<UserCredential> signIn(String email, String password) async {
+    final credential = await _auth.signInWithEmailAndPassword(
       email: email,
       password: password,
     );
+    if (!credential.user!.emailVerified) {
+      await _auth.signOut();
+      throw FirebaseAuthException(code: 'email-not-verified');
+    }
+    // Save/update user in Firestore only after first verified login
     await _db.collection('users').doc(credential.user!.uid).set({
       'email': email,
       'createdAt': FieldValue.serverTimestamp(),
     }, SetOptions(merge: true));
     return credential;
+  }
+
+  Future<void> register(String email, String password) async {
+    final credential = await _auth.createUserWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+    await credential.user!.sendEmailVerification();
+    // Sign out immediately — user must verify email before accessing the app
+    await _auth.signOut();
+  }
+
+  Future<void> sendVerificationEmail() async {
+    await _auth.currentUser?.sendEmailVerification();
   }
 
   Future<void> signOut() => _auth.signOut();

--- a/lost_found_app/lib/views/login/login_view.dart
+++ b/lost_found_app/lib/views/login/login_view.dart
@@ -36,6 +36,9 @@ class _LoginViewState extends State<LoginView> {
     } on FirebaseAuthException catch (e) {
       setState(() {
         switch (e.code) {
+          case 'email-not-verified':
+            _errorMessage =
+                'Your email is not verified yet. Please check your inbox and click the verification link.';
           case 'user-not-found':
           case 'wrong-password':
           case 'invalid-credential':

--- a/lost_found_app/lib/views/login/register_view.dart
+++ b/lost_found_app/lib/views/login/register_view.dart
@@ -36,9 +36,27 @@ class _RegisterViewState extends State<RegisterView> {
         password: _passwordController.text,
         confirmPassword: _confirmPasswordController.text,
       );
-      // Pop back to root so the StreamBuilder in app.dart can show HomeView.
       if (mounted) {
-        Navigator.of(context).popUntil((route) => route.isFirst);
+        showDialog<void>(
+          context: context,
+          barrierDismissible: false,
+          builder: (_) => AlertDialog(
+            title: const Text('Check your inbox'),
+            content: const Text(
+              'A verification link has been sent to your email address. '
+              'Please verify your email before logging in.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).pop(); // close dialog
+                  Navigator.of(context).popUntil((route) => route.isFirst); // back to login
+                },
+                child: const Text('Go to Login'),
+              ),
+            ],
+          ),
+        );
       }
     } on FirebaseAuthException catch (e) {
       setState(() {


### PR DESCRIPTION
Send a verification email after sign-up and sign the user out immediately. Block login for unverified accounts and move Firestore user creation to first verified login. Guard HomeView in StreamBuilder with emailVerified check.